### PR TITLE
Fix: Linked footer navbar links to matching sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,11 +212,11 @@
             </div>
             <div class="box">
                 <h2>Navbars</h2>
-                <a href="#">Home</a>
-                <a href="#">Protect</a>
-                <a href="#">Symtoms</a>
-                <a href="#">Precautions</a>
-                <a href="#">Spread</a>
+                <a href="#home">Home</a>
+                <a href="protect.html">Protection</a>
+                <a href="#symtoms">Symtoms</a>
+                <a href="#precautions">Precautions</a>
+                <a href="#spread">Spread News</a>
             </div>
             <div class="box">
                 <h2>Contact Info</h2>


### PR DESCRIPTION
# Description

Navbar links in the footer section do not link to their matching section.
I have fixed it by editing href attributes of them and linking them to their matching section.

Fixes:  #21

<!---give the issue number you fixed----->

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] I have made this from my own
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK

![Peek 2022-07-19 07-59](https://user-images.githubusercontent.com/74391865/179651277-d6e55bc0-9592-467e-8d75-6fad2e6118c2.gif)


