### PR TITLE
fix: remove left-margin and add flex to align list items

### DIFF
--- a/style.css
+++ b/style.css
@@ -299,7 +299,8 @@ header .navbar ul li a:hover{
     align-items: center;
     justify-content: center;
     flex-wrap: wrap;
-    padding:2rem 0;
+    padding: 2rem 0;
+    gap: 10px;
 }
 
 .precautions .row .image{
@@ -314,14 +315,17 @@ header .navbar ul li a:hover{
     object-fit: cover;
 }
 
-.precautions .row .content{
-    padding:2rem 0;
-    flex:1 1 37rem;
+.precautions .row .content {
+    padding: 2rem 0;
+    flex: 1 1 37rem;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    align-items: center;
 }
 
 .precautions .row .content .heading{
     color: rgb(128, 128, 128);
-    margin-left: 20rem;
 }
 
 .precautions .row .content p{
@@ -335,7 +339,6 @@ header .navbar ul li a:hover{
     font-size: 2rem;
     color: var(--precautions-content);
     padding:.5rem 0;
-    margin-left: 22rem;
 }
 
 


### PR DESCRIPTION
# Description

Removed the left margin from the **things not to do** section and use flex to align ul and list items in the center. 

Fixes:  #36

<!---give the issue number you fixed----->

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] I have made this from my own
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
# Before 
![image](https://user-images.githubusercontent.com/74391865/180588607-2f3495c6-3fc1-46ad-904f-9507492fdc44.png)

# After
![image](https://user-images.githubusercontent.com/74391865/181235298-1b312581-ab0e-48df-9dcf-e056609f9faf.png)


